### PR TITLE
Update MoviePy import for v2 compatibility

### DIFF
--- a/skyreels_ui.py
+++ b/skyreels_ui.py
@@ -60,9 +60,16 @@ _ensure_base_packages()
 
 import gradio as gr
 from PIL import Image, ImageDraw, ImageFont
-from moviepy.editor import (VideoFileClip, concatenate_videoclips, CompositeVideoClip,
-                            AudioFileClip, ImageClip)
-import moviepy.video.fx.all as vfx
+# MoviePy v2-importer (editor-navnerommet er fjernet)
+from moviepy import (
+    VideoFileClip,
+    concatenate_videoclips,
+    CompositeVideoClip,
+    AudioFileClip,
+    ImageClip,
+    TextClip,
+    vfx,  # effektklasser, f.eks. vfx.FadeIn / vfx.FadeOut
+)
 from moviepy.audio.AudioClip import CompositeAudioClip
 
 def _has_module(name: str) -> bool:


### PR DESCRIPTION
## Summary
- switch to MoviePy v2-style imports using `from moviepy import ...`

## Testing
- `python -m py_compile skyreels_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03c0c4f608320b9214b6077844a34